### PR TITLE
Make HTTPResponseStatus factory method public

### DIFF
--- a/Sources/NIOHTTP1/HTTPDecoder.swift
+++ b/Sources/NIOHTTP1/HTTPDecoder.swift
@@ -202,7 +202,7 @@ public class HTTPDecoder<HTTPMessageT>: ByteToMessageDecoder, AnyHTTPDecoder {
     }
 
     private func newResponseHead(_ parser: UnsafeMutablePointer<http_parser>!) -> HTTPResponseHead {
-        let status = HTTPResponseStatus.from(parser.pointee.status_code, state.currentStatus!)
+        let status = HTTPResponseStatus(statusCode: Int(parser.pointee.status_code), reasonPhrase: state.currentStatus!)
         let version = HTTPVersion(major: parser.pointee.http_major, minor: parser.pointee.http_minor)
         let response = HTTPResponseHead(version: version, status: status, headers: state.currentHeaders ?? HTTPHeaders())
         state.currentHeaders = nil
@@ -574,139 +574,6 @@ extension HTTPMethod {
             return .UNLINK
         default:
             fatalError("Unexpected http_method \(httpParserMethod)")
-        }
-    }
-}
-
-extension HTTPResponseStatus {
-    /// Create a `HTTPResponseStatus` from a given status and reason produced by
-    /// `http_parser`.
-    ///
-    /// - Parameter statusCode: The integer value of the HTTP response status code
-    /// - Parameter reasonPhrase: The textual reason phrase from the response.
-    /// - Returns: The corresponding `HTTPResponseStatus`.
-    static func from(_ statusCode: UInt32, _ reasonPhrase: String) -> HTTPResponseStatus {
-        switch statusCode {
-        case 100:
-            return .`continue`
-        case 101:
-            return .switchingProtocols
-        case 102:
-            return .processing
-        case 200:
-            return .ok
-        case 201:
-            return .created
-        case 202:
-            return .accepted
-        case 203:
-            return .nonAuthoritativeInformation
-        case 204:
-            return .noContent
-        case 205:
-            return .resetContent
-        case 206:
-            return .partialContent
-        case 207:
-            return .multiStatus
-        case 208:
-            return .alreadyReported
-        case 226:
-            return .imUsed
-        case 300:
-            return .multipleChoices
-        case 301:
-            return .movedPermanently
-        case 302:
-            return .found
-        case 303:
-            return .seeOther
-        case 304:
-            return .notModified
-        case 305:
-            return .useProxy
-        case 307:
-            return .temporaryRedirect
-        case 308:
-            return .permanentRedirect
-        case 400:
-            return .badRequest
-        case 401:
-            return .unauthorized
-        case 402:
-            return .paymentRequired
-        case 403:
-            return .forbidden
-        case 404:
-            return .notFound
-        case 405:
-            return .methodNotAllowed
-        case 406:
-            return .notAcceptable
-        case 407:
-            return .proxyAuthenticationRequired
-        case 408:
-            return .requestTimeout
-        case 409:
-            return .conflict
-        case 410:
-            return .gone
-        case 411:
-            return .lengthRequired
-        case 412:
-            return .preconditionFailed
-        case 413:
-            return .payloadTooLarge
-        case 414:
-            return .uriTooLong
-        case 415:
-            return .unsupportedMediaType
-        case 416:
-            return .rangeNotSatisfiable
-        case 417:
-            return .expectationFailed
-        case 421:
-            return .misdirectedRequest
-        case 422:
-            return .unprocessableEntity
-        case 423:
-            return .locked
-        case 424:
-            return .failedDependency
-        case 426:
-            return .upgradeRequired
-        case 428:
-            return .preconditionRequired
-        case 429:
-            return .tooManyRequests
-        case 431:
-            return .requestHeaderFieldsTooLarge
-        case 451:
-            return .unavailableForLegalReasons
-        case 500:
-            return .internalServerError
-        case 501:
-            return .notImplemented
-        case 502:
-            return .badGateway
-        case 503:
-            return .serviceUnavailable
-        case 504:
-            return .gatewayTimeout
-        case 505:
-            return .httpVersionNotSupported
-        case 506:
-            return .variantAlsoNegotiates
-        case 507:
-            return .insufficientStorage
-        case 508:
-            return .loopDetected
-        case 510:
-            return .notExtended
-        case 511:
-            return .networkAuthenticationRequired
-        default:
-            return .custom(code: UInt(statusCode), reasonPhrase: reasonPhrase)
         }
     }
 }

--- a/Sources/NIOHTTP1/HTTPTypes.swift
+++ b/Sources/NIOHTTP1/HTTPTypes.swift
@@ -1097,6 +1097,136 @@ public enum HTTPResponseStatus {
             return true
         }
     }
+
+    /// Initialize a `HTTPResponseStatus` from a given status and reason.
+    ///
+    /// - Parameter statusCode: The integer value of the HTTP response status code
+    /// - Parameter reasonPhrase: The textual reason phrase from the response. This will be 
+    ///     discarded in favor of the default if the `statusCode` matches one that we know.
+    public init(statusCode: Int, reasonPhrase: String = "") {
+        switch statusCode {
+        case 100:
+            self = .`continue`
+        case 101:
+            self = .switchingProtocols
+        case 102:
+            self = .processing
+        case 200:
+            self = .ok
+        case 201:
+            self = .created
+        case 202:
+            self = .accepted
+        case 203:
+            self = .nonAuthoritativeInformation
+        case 204:
+            self = .noContent
+        case 205:
+            self = .resetContent
+        case 206:
+            self = .partialContent
+        case 207:
+            self = .multiStatus
+        case 208:
+            self = .alreadyReported
+        case 226:
+            self = .imUsed
+        case 300:
+            self = .multipleChoices
+        case 301:
+            self = .movedPermanently
+        case 302:
+            self = .found
+        case 303:
+            self = .seeOther
+        case 304:
+            self = .notModified
+        case 305:
+            self = .useProxy
+        case 307:
+            self = .temporaryRedirect
+        case 308:
+            self = .permanentRedirect
+        case 400:
+            self = .badRequest
+        case 401:
+            self = .unauthorized
+        case 402:
+            self = .paymentRequired
+        case 403:
+            self = .forbidden
+        case 404:
+            self = .notFound
+        case 405:
+            self = .methodNotAllowed
+        case 406:
+            self = .notAcceptable
+        case 407:
+            self = .proxyAuthenticationRequired
+        case 408:
+            self = .requestTimeout
+        case 409:
+            self = .conflict
+        case 410:
+            self = .gone
+        case 411:
+            self = .lengthRequired
+        case 412:
+            self = .preconditionFailed
+        case 413:
+            self = .payloadTooLarge
+        case 414:
+            self = .uriTooLong
+        case 415:
+            self = .unsupportedMediaType
+        case 416:
+            self = .rangeNotSatisfiable
+        case 417:
+            self = .expectationFailed
+        case 421:
+            self = .misdirectedRequest
+        case 422:
+            self = .unprocessableEntity
+        case 423:
+            self = .locked
+        case 424:
+            self = .failedDependency
+        case 426:
+            self = .upgradeRequired
+        case 428:
+            self = .preconditionRequired
+        case 429:
+            self = .tooManyRequests
+        case 431:
+            self = .requestHeaderFieldsTooLarge
+        case 451:
+            self = .unavailableForLegalReasons
+        case 500:
+            self = .internalServerError
+        case 501:
+            self = .notImplemented
+        case 502:
+            self = .badGateway
+        case 503:
+            self = .serviceUnavailable
+        case 504:
+            self = .gatewayTimeout
+        case 505:
+            self = .httpVersionNotSupported
+        case 506:
+            self = .variantAlsoNegotiates
+        case 507:
+            self = .insufficientStorage
+        case 508:
+            self = .loopDetected
+        case 510:
+            self = .notExtended
+        case 511:
+            self = .networkAuthenticationRequired
+        default:
+            self = .custom(code: UInt(statusCode), reasonPhrase: reasonPhrase)
+        }
+    }
 }
 
 extension HTTPResponseStatus: Equatable {


### PR DESCRIPTION
This allows creating `HTTPResponseStatus` values from raw status codes.

### Motivation:

Currently one would have to make a `custom` `HTTPResponseStatus`. The problem with that is that `HTTPResponseStatus.custom(code: 200, reasonPhrase: "") != HTTPResponseStatus.ok`.

#### Considerations
* It might make more sense for this extension to move to the same file where `HTTPResponseStatus` is defined.
* Another thing to be considered is whether the signature should be changed to make is clear that it is a factory method (according to the Swift API guidelines), e.g. `makeStatus(statusCode: UInt32, reasonPhrase: String)`.
* `reasonPhrase` could receive a default value, ie. `reasonPhrase: String = ""`

### Modifications:

Added `public` access modifier.

### Result:

A `HTTPResponseStatus` value can be created using `HTTPResponseStatus.from(200, reasonPhrase: "")` which will result in `HTTPResponseStatus.ok`